### PR TITLE
Fix modal closing when clicking on contributor links

### DIFF
--- a/app.js
+++ b/app.js
@@ -400,14 +400,21 @@
             ref: aboutButtonRef
           }, 'About')
         ),
-        isAboutOpen && React.createElement('div', { className: 'modal-overlay', role: 'presentation', onClick: toggleAbout },
+        isAboutOpen && React.createElement('div', {
+          className: 'modal-overlay',
+          role: 'presentation',
+          onClick: (e) => {
+            if (e.target === e.currentTarget) {
+              toggleAbout();
+            }
+          }
+        },
           React.createElement('div', {
             className: 'modal-content',
             role: 'dialog',
             id: 'about-dialog',
             'aria-modal': 'true',
-            'aria-labelledby': 'about-dialog-title',
-            onClick: (e) => e.stopPropagation()
+            'aria-labelledby': 'about-dialog-title'
           },
             React.createElement('div', { className: 'modal-header' },
               React.createElement('h2', { id: 'about-dialog-title' }, 'About TheCommunity'),


### PR DESCRIPTION
## Bug Fix

Fixes a bug where clicking on contributor links inside the About modal would close the modal unexpectedly.

### Changes
- Updated modal overlay click handler to only close when clicking directly on the overlay background
- Links and content inside the modal can now be clicked without closing it

### Testing
- Open the About modal
- Click on contributor links - modal should stay open
- Click on the dark background outside the modal - modal should close