### PR TITLE
Add disconnect button

### DIFF
--- a/app.js
+++ b/app.js
@@ -295,6 +295,29 @@
       setInputText('');
     }, [appendMessage, appendSystemMessage, inputText]);
 
+    /**
+     * Closes the data channel and peer connection, resetting to initial state.
+     */
+    const handleDisconnect = useCallback(() => {
+      if (channelRef.current) {
+        channelRef.current.close();
+        channelRef.current = null;
+      }
+      if (pcRef.current) {
+        pcRef.current.close();
+        pcRef.current = null;
+      }
+      iceDoneRef.current = false;
+      incomingTimestampsRef.current = [];
+      setChannelReady(false);
+      setChannelStatus('Channel closed');
+      setStatus('Disconnected');
+      setLocalSignal('');
+      setRemoteSignal('');
+      setIsSignalingCollapsed(false);
+      appendSystemMessage('Connection closed. Create a new offer to reconnect.');
+    }, [appendSystemMessage]);
+
     const toggleSignalingCollapse = useCallback(() => {
       setIsSignalingCollapsed((prev) => !prev);
     }, []);
@@ -535,7 +558,13 @@
               React.createElement('button', {
                 id: 'apply-remote',
                 onClick: handleApplyRemote
-              }, 'Apply Remote')
+              }, 'Apply Remote'),
+              React.createElement('button', {
+                id: 'disconnect',
+                onClick: handleDisconnect,
+                disabled: !channelReady,
+                'aria-label': 'Disconnect from peer'
+              }, 'Disconnect')
             ),
             React.createElement('label', null,
               React.createElement('strong', null, 'Local Signal (share this)'),


### PR DESCRIPTION
## Summary
- Adds a "Disconnect" button in the signaling controls
- Only enabled when connected to a peer
- Closes data channel and peer connection, resets to initial state
- Expands signaling window and shows system message

## Test plan
- [x] Connect to a peer
- [x] Click the Disconnect button
- [x] Verify connection closes properly
- [x] Verify state resets to initial
- [x] Verify signaling window expands

🤖 Generated with [Claude Code](https://claude.com/claude-code)