### PR TITLE
feat: add optional OpenAI draft assistance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ TheCommunity is a community-driven project that demonstrates true peer-to-peer c
 - **Message History** - Visual distinction between your messages, peer messages, and system notices
 - **Auto-scroll** - Messages automatically scroll to show the latest content
 - **Input Validation** - Client-side validation for message length and format
+- **AI Draft Assistance** - Optional OpenAI-powered rewrite button that refines your text locally using your own API key
 
 ### 🎨 User Interface
 - **Collapsible Signaling Window** - Hide the technical signaling UI once connected
@@ -82,6 +83,13 @@ Since there's no signaling server, users manually exchange WebRTC signals:
    - Once connected, the signaling window can be collapsed
    - Messages flow directly peer-to-peer
    - No server involvement in the conversation
+
+### AI Draft Assistance (Optional)
+
+1. When the app starts you can paste a personal OpenAI API key. The key stays in browser memory only and is sent exclusively to `api.openai.com`.
+2. Draft a message and click **Rewrite with AI** to request a refined version. The result replaces your local draft so you can review it before sending.
+3. Use **Update OpenAI Key** in the chat header any time to rotate or remove the key.
+4. Choose **Disable AI** or refresh the page to clear the key completely. You are responsible for any usage charges billed to your OpenAI account.
 
 ### WebRTC Architecture
 
@@ -176,12 +184,14 @@ TheCommunity/
 - ❌ Authenticate users
 - ❌ Persist message history
 - ❌ Hide your IP address from peers
+- ❌ Proxy OpenAI requests on your behalf (your browser talks to api.openai.com directly with your key)
 
 ### Recommendations
 - Only connect with people you trust
 - Don't share sensitive information
 - Be aware that your IP address is visible to peers
 - Consider using a VPN if privacy is a concern
+- Treat your OpenAI API key like a password and only enter it on devices you control
 
 ## Development
 

--- a/styles.css
+++ b/styles.css
@@ -219,6 +219,80 @@ textarea[readonly] {
   opacity: 0.6;
   cursor: not-allowed;
 }
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.header-actions > button {
+  flex: 0 0 auto;
+}
+.api-key-button {
+  min-width: 170px;
+}
+.ai-button {
+  min-width: 160px;
+  white-space: nowrap;
+}
+.modal-description {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin: 0 0 0.75rem;
+  color: #e0e3eb;
+}
+.modal-label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+.api-key-form input {
+  margin-top: 0.5rem;
+  margin-bottom: 0.75rem;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  border: 1px solid #5f6368;
+  background: #111217;
+  color: inherit;
+  font-size: 1rem;
+  transition: border-color 200ms ease, background-color 200ms ease;
+}
+.api-key-form input:focus {
+  border-color: #8ab4f8;
+  outline: 2px solid #8ab4f8;
+  outline-offset: 2px;
+}
+.modal-error {
+  color: #ffb4b4;
+  font-size: 0.9rem;
+  margin: 0;
+}
+.modal-hint {
+  font-size: 0.85rem;
+  color: #ffffff;
+  opacity: 0.7;
+  margin-top: 0.25rem;
+}
+.modal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+.modal-actions button {
+  flex: 1 1 150px;
+}
+.ai-feedback {
+  margin-top: 0.4rem;
+  text-align: right;
+  opacity: 0.75;
+}
+.ai-feedback-error {
+  color: #ffb4b4;
+  opacity: 1;
+}
 .status {
   font-size: 0.95rem;
   color: #ffffff;
@@ -510,6 +584,20 @@ textarea[readonly] {
     padding: 0.85rem 1.1rem;
     font-size: 0.95rem;
   }
+  .header-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .header-actions > button {
+    width: 100%;
+  }
+  .modal-actions {
+    flex-direction: column;
+  }
+  .modal-actions button {
+    width: 100%;
+    flex: 1 1 auto;
+  }
   .hint {
     font-size: 0.8rem;
   }
@@ -566,6 +654,20 @@ textarea[readonly] {
   .chat-input button {
     width: 100%;
     min-height: 44px;
+  }
+  .header-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .header-actions > button {
+    width: 100%;
+  }
+  .modal-actions {
+    flex-direction: column;
+  }
+  .modal-actions button {
+    width: 100%;
+    flex: 1 1 auto;
   }
   .modal-header {
     padding: 1.25rem 1.5rem;


### PR DESCRIPTION
## Summary
- prompt users for an OpenAI API key that is stored only in-memory and can be updated or disabled later
- add an optional ‘Rewrite with AI’ action that refines the current draft using the supplied key while preserving WebRTC-only architecture
- update styling and documentation to explain the AI workflow and security implications

## Testing
- node --check app.js