### PR TITLE
Add angry Tux mascot to header

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,185 @@
   };
 
   /**
+   * Renders the mascot that reacts angrily on hover.
+   * Pure SVG so it can be reused without additional assets.
+   * @returns {React.ReactElement}
+   */
+  function TuxMascot() {
+    const svgChildren = [
+      React.createElement('ellipse', {
+        key: 'shadow',
+        className: 'tux-shadow',
+        cx: '60',
+        cy: '112',
+        rx: '24',
+        ry: '8'
+      }),
+      React.createElement('ellipse', {
+        key: 'body',
+        className: 'tux-body',
+        cx: '60',
+        cy: '60',
+        rx: '32',
+        ry: '46'
+      }),
+      React.createElement('ellipse', {
+        key: 'belly',
+        className: 'tux-belly',
+        cx: '60',
+        cy: '78',
+        rx: '22',
+        ry: '28'
+      }),
+      React.createElement('ellipse', {
+        key: 'head',
+        className: 'tux-head',
+        cx: '60',
+        cy: '38',
+        rx: '26',
+        ry: '24'
+      }),
+      React.createElement('ellipse', {
+        key: 'face',
+        className: 'tux-face',
+        cx: '60',
+        cy: '47',
+        rx: '20',
+        ry: '15'
+      }),
+      React.createElement('ellipse', {
+        key: 'wing-left',
+        className: 'tux-wing wing-left',
+        cx: '33',
+        cy: '70',
+        rx: '11',
+        ry: '24'
+      }),
+      React.createElement('ellipse', {
+        key: 'wing-right',
+        className: 'tux-wing wing-right',
+        cx: '87',
+        cy: '70',
+        rx: '11',
+        ry: '24'
+      }),
+      React.createElement('path', {
+        key: 'foot-left',
+        className: 'tux-foot foot-left',
+        d: 'M44 96 C40 104 44 110 52 110 L58 110 C64 110 66 104 62 96 L56 88 Z'
+      }),
+      React.createElement('path', {
+        key: 'foot-right',
+        className: 'tux-foot foot-right',
+        d: 'M76 96 C72 104 76 110 84 110 L90 110 C96 110 98 104 94 96 L88 88 Z'
+      }),
+      React.createElement('polygon', {
+        key: 'beak-upper',
+        className: 'tux-beak-upper',
+        points: '60,50 48,56 72,56'
+      }),
+      React.createElement('ellipse', {
+        key: 'beak-lower',
+        className: 'tux-beak-lower',
+        cx: '60',
+        cy: '60',
+        rx: '12',
+        ry: '5'
+      }),
+      React.createElement('circle', {
+        key: 'eye-left',
+        className: 'tux-eye eye-left',
+        cx: '50',
+        cy: '44',
+        r: '7'
+      }),
+      React.createElement('circle', {
+        key: 'eye-right',
+        className: 'tux-eye eye-right',
+        cx: '70',
+        cy: '44',
+        r: '7'
+      }),
+      React.createElement('circle', {
+        key: 'pupil-left',
+        className: 'tux-pupil pupil-left',
+        cx: '52',
+        cy: '46',
+        r: '3'
+      }),
+      React.createElement('circle', {
+        key: 'pupil-right',
+        className: 'tux-pupil pupil-right',
+        cx: '68',
+        cy: '46',
+        r: '3'
+      }),
+      React.createElement('circle', {
+        key: 'glow-left',
+        className: 'tux-eye-glow glow-left',
+        cx: '50',
+        cy: '44',
+        r: '7'
+      }),
+      React.createElement('circle', {
+        key: 'glow-right',
+        className: 'tux-eye-glow glow-right',
+        cx: '70',
+        cy: '44',
+        r: '7'
+      }),
+      React.createElement('rect', {
+        key: 'brow-left',
+        className: 'tux-brow brow-left',
+        x: '42',
+        y: '32',
+        width: '16',
+        height: '3',
+        rx: '1.5'
+      }),
+      React.createElement('rect', {
+        key: 'brow-right',
+        className: 'tux-brow brow-right',
+        x: '62',
+        y: '32',
+        width: '16',
+        height: '3',
+        rx: '1.5'
+      }),
+      React.createElement('path', {
+        key: 'steam-left',
+        className: 'tux-steam steam-left',
+        d: 'M32 20 C28 14 31 10 35 8 C39 6 40 4 38 2'
+      }),
+      React.createElement('path', {
+        key: 'steam-right',
+        className: 'tux-steam steam-right',
+        d: 'M88 20 C92 14 89 10 85 8 C81 6 80 4 82 2'
+      })
+    ];
+
+    return React.createElement(
+      'div',
+      {
+        className: 'tux-mascot',
+        role: 'img',
+        'aria-label': 'Angry Tux mascot, hover to rile him up'
+      },
+      React.createElement(
+        'svg',
+        {
+          className: 'tux-svg',
+          viewBox: '0 0 120 120',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'aria-hidden': 'true',
+          focusable: 'false'
+        },
+        svgChildren
+      )
+    );
+  }
+
+  /**
    * Determines the initial theme, preferring stored settings, then system preference.
    * @returns {{theme: 'light'|'dark', isStored: boolean}}
    */
@@ -814,6 +993,7 @@
         ),
         React.createElement('main', null,
           React.createElement('div', { className: 'header-with-about' },
+            React.createElement(TuxMascot, null),
             React.createElement('h1', { className: 'app-title' },
               React.createElement('span', {
                 className: 'app-title-icon',

--- a/styles.css
+++ b/styles.css
@@ -108,6 +108,9 @@ h1 {
   align-items: center;
   gap: 1rem;
   position: relative;
+  width: 100%;
+  min-height: clamp(88px, 12vw, 128px);
+  padding: 0 clamp(3.5rem, 8vw, 4.75rem);
 }
 .app-title {
   display: inline-flex;
@@ -122,6 +125,193 @@ h1 {
 }
 .app-title-text {
   white-space: nowrap;
+}
+.tux-mascot {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  --tux-rest-transform: translateY(-50%);
+  --tux-hover-transform: translateY(-50%) scale(1.06);
+  transform: var(--tux-rest-transform);
+  width: clamp(64px, 8vw, 82px);
+  height: clamp(64px, 8vw, 82px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  transition: transform 200ms ease;
+  z-index: 1;
+}
+.tux-mascot:hover {
+  transform: var(--tux-hover-transform);
+}
+.tux-svg {
+  width: 100%;
+  height: 100%;
+}
+.tux-shadow {
+  fill: rgba(0, 0, 0, 0.32);
+  transition: opacity 150ms ease;
+}
+.tux-mascot:hover .tux-shadow {
+  opacity: 0.55;
+}
+.tux-body,
+.tux-head {
+  fill: #1d2132;
+}
+.tux-face,
+.tux-belly {
+  fill: #f5f7ff;
+}
+.tux-wing {
+  fill: #181b27;
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: transform 120ms ease;
+}
+.tux-wing.wing-left {
+  transform: rotate(-18deg);
+}
+.tux-wing.wing-right {
+  transform: rotate(18deg);
+}
+.tux-foot {
+  fill: #f7a531;
+  stroke: #d87f1a;
+  stroke-width: 2;
+}
+.tux-beak-upper {
+  fill: #f9b13a;
+}
+.tux-beak-lower {
+  fill: #d7801a;
+}
+.tux-eye {
+  fill: #ffffff;
+  transition: fill 150ms ease;
+}
+.tux-pupil {
+  fill: #10131c;
+  transition: transform 150ms ease, fill 150ms ease;
+}
+.tux-eye-glow {
+  fill: #ff5050;
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+.tux-brow {
+  fill: #1a1e2c;
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: transform 150ms ease;
+}
+.tux-steam {
+  fill: none;
+  stroke: #ff8a8a;
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  opacity: 0;
+  transform-box: fill-box;
+  transform-origin: bottom center;
+}
+.tux-mascot:hover .wing-left {
+  animation: tux-wing-left 360ms ease-in-out infinite;
+}
+.tux-mascot:hover .wing-right {
+  animation: tux-wing-right 360ms ease-in-out infinite;
+}
+.tux-mascot:hover .tux-body,
+.tux-mascot:hover .tux-head,
+.tux-mascot:hover .tux-face,
+.tux-mascot:hover .tux-belly {
+  animation: tux-body-shake 140ms ease-in-out infinite;
+}
+.tux-mascot:hover .tux-eye {
+  fill: #ffe5e5;
+}
+.tux-mascot:hover .tux-eye-glow {
+  opacity: 0.85;
+}
+.tux-mascot:hover .tux-pupil {
+  transform: translateY(2px) scale(0.82);
+  fill: #05070c;
+}
+.tux-mascot:hover .brow-left {
+  transform: rotate(-42deg) translate(-4px, 2px);
+}
+.tux-mascot:hover .brow-right {
+  transform: rotate(42deg) translate(4px, 2px);
+}
+.tux-mascot:hover .steam-left {
+  animation: tux-steam-rise 620ms ease-out infinite;
+  animation-delay: 80ms;
+}
+.tux-mascot:hover .steam-right {
+  animation: tux-steam-rise 620ms ease-out infinite;
+  animation-delay: 160ms;
+}
+
+@keyframes tux-wing-left {
+  0%, 100% {
+    transform: rotate(-18deg);
+  }
+  50% {
+    transform: rotate(-36deg) translateY(-3px);
+  }
+}
+@keyframes tux-wing-right {
+  0%, 100% {
+    transform: rotate(18deg);
+  }
+  50% {
+    transform: rotate(36deg) translateY(-3px);
+  }
+}
+@keyframes tux-body-shake {
+  0%, 100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-1.6px);
+  }
+  75% {
+    transform: translateX(1.6px);
+  }
+}
+@keyframes tux-steam-rise {
+  0% {
+    opacity: 0;
+    transform: translateY(0) scale(0.85);
+  }
+  40% {
+    opacity: 0.9;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-12px) scale(1.1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tux-mascot {
+    transition: none;
+    --tux-hover-transform: var(--tux-rest-transform);
+  }
+  .tux-mascot:hover {
+    transition: none;
+  }
+  .tux-mascot:hover .wing-left,
+  .tux-mascot:hover .wing-right,
+  .tux-mascot:hover .tux-body,
+  .tux-mascot:hover .tux-head,
+  .tux-mascot:hover .tux-face,
+  .tux-mascot:hover .tux-belly,
+  .tux-mascot:hover .steam-left,
+  .tux-mascot:hover .steam-right {
+    animation: none !important;
+  }
 }
 .about-button {
   position: absolute;
@@ -592,6 +782,15 @@ textarea[readonly] {
   .header-with-about {
     flex-direction: column;
     gap: 0.75rem;
+    padding: 0;
+  }
+  .tux-mascot {
+    position: static;
+    --tux-rest-transform: none;
+    --tux-hover-transform: scale(1.08);
+    margin-bottom: 0.3rem;
+    width: 72px;
+    height: 72px;
   }
   .about-button {
     position: static;
@@ -697,6 +896,15 @@ textarea[readonly] {
   .header-with-about {
     flex-direction: column;
     gap: 0.75rem;
+    padding: 0;
+  }
+  .tux-mascot {
+    position: static;
+    --tux-rest-transform: none;
+    --tux-hover-transform: scale(1.08);
+    margin-bottom: 0.5rem;
+    width: 76px;
+    height: 76px;
   }
   .about-button {
     position: static;
@@ -760,6 +968,15 @@ textarea[readonly] {
   .header-with-about {
     flex-direction: column;
     gap: 0.75rem;
+    padding: 0;
+  }
+  .tux-mascot {
+    position: static;
+    --tux-rest-transform: none;
+    --tux-hover-transform: scale(1.08);
+    margin-bottom: 0.5rem;
+    width: 82px;
+    height: 82px;
   }
   .about-button {
     position: static;
@@ -801,6 +1018,15 @@ textarea[readonly] {
   .header-with-about {
     flex-direction: column;
     gap: 0.75rem;
+    padding: 0;
+  }
+  .tux-mascot {
+    position: static;
+    --tux-rest-transform: none;
+    --tux-hover-transform: scale(1.06);
+    margin-bottom: 0.5rem;
+    width: 84px;
+    height: 84px;
   }
   .about-button {
     position: static;


### PR DESCRIPTION
## Summary
- add a reusable `TuxMascot` component that renders an angry hover animation
- position the mascot beside the existing title with responsive layout handling
- craft CSS-driven hover states, motion safeguards, and reduced-motion fallbacks for accessibility

## Testing
- not run (static frontend)

Closes #35