### PR TITLE
Allow Claude review for non-write actors

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,11 +31,18 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Allow Claude for non-write actors
+        shell: bash
+        run: echo "OVERRIDE_GITHUB_TOKEN=${GITHUB_TOKEN}" >> "$GITHUB_ENV"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_non_write_users: '*'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- expose the workflow token via OVERRIDE_GITHUB_TOKEN before the Claude review step so non-write actors can run it
- set allowed_non_write_users to '*' to bypass the write-permission guard once the override token is available

## Testing
- gh run rerun 18582003359 (after merge)
