### PR TITLE
Fix: Add missing id-token permission to claude-code-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,6 +23,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
Adds the missing `id-token: write` permission to the `claude-code-review` workflow.

## Problem
PR #41 failed with error:
```
Error: Failed to setup GitHub token: Error: Could not fetch an OIDC token. 
Did you remember to add `id-token: write` to your workflow permissions?
```

## Solution
Added `id-token: write` permission back to the workflow. This permission is required by the Claude Code action to fetch an OIDC token for authentication.

## Changes
- Added `id-token: write` to permissions in `.github/workflows/claude-code-review.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)