### PR TITLE
play ascii chess in chat with opponent

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -40,6 +40,12 @@ export const TRIVIA_CHANNEL_LABEL = 'trivia';
 export const FLAPPYBIRD_CHANNEL_LABEL = 'flappybird';
 
 /**
+ * Label for the Chess game data channel.
+ * @constant {string}
+ */
+export const CHESS_CHANNEL_LABEL = 'chess';
+
+/**
  * Maximum allowed length for a chat message in characters.
  * @constant {number}
  */

--- a/src/managers/ChessManager.js
+++ b/src/managers/ChessManager.js
@@ -1,0 +1,382 @@
+/**
+ * @fileoverview Chess Manager - Handles chess game logic and synchronization
+ * @module managers/ChessManager
+ *
+ * This manager handles:
+ * - Chess game state (board, current player, piece positions)
+ * - ASCII board rendering
+ * - Move validation (basic - no complex rules for now)
+ * - Turn management
+ * - Synchronization over WebRTC data channel
+ * - Game lifecycle (start, move, end)
+ */
+
+import { CHESS_CHANNEL_LABEL } from '../core/constants.js';
+
+/**
+ * Creates a factory for Chess game operations
+ * @param {Object} deps - Dependencies object
+ * @param {React.MutableRefObject} deps.chessChannelRef - Chess data channel reference
+ * @param {Function} deps.appendMessage - Message appender function
+ * @param {Function} deps.appendSystemMessage - System message appender
+ * @param {Object} deps.t - Translation object
+ * @returns {Object} Chess game operations
+ * @export
+ */
+export function createChessManager(deps) {
+  const {
+    chessChannelRef,
+    appendMessage,
+    appendSystemMessage,
+    t
+  } = deps;
+
+  // Game state
+  let gameState = null;
+  let isWhite = false; // Whether this player plays white pieces
+
+  /**
+   * Initializes the game state with standard chess starting position
+   * @param {boolean} asWhite - Whether this player plays white (white starts)
+   */
+  function initializeGameState(asWhite) {
+    isWhite = asWhite;
+
+    // Standard chess starting position
+    // Uppercase = White pieces, Lowercase = Black pieces
+    // K/k = King, Q/q = Queen, R/r = Rook, N/n = Knight, B/b = Bishop, P/p = Pawn
+    gameState = {
+      board: [
+        ['r', 'n', 'b', 'q', 'k', 'b', 'n', 'r'], // Black back rank
+        ['p', 'p', 'p', 'p', 'p', 'p', 'p', 'p'], // Black pawns
+        [' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '],
+        [' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '],
+        [' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '],
+        [' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '],
+        ['P', 'P', 'P', 'P', 'P', 'P', 'P', 'P'], // White pawns
+        ['R', 'N', 'B', 'Q', 'K', 'B', 'N', 'R']  // White back rank
+      ],
+      whiteToMove: true,
+      gameActive: true
+    };
+  }
+
+  /**
+   * Renders the chess board as ASCII art
+   * @returns {string} ASCII representation of the board
+   */
+  function renderBoard() {
+    if (!gameState) return '';
+
+    const letters = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+    let ascii = '\n```\n';
+    ascii += '  +---+---+---+---+---+---+---+---+\n';
+
+    for (let row = 0; row < 8; row++) {
+      const rowNum = 8 - row;
+      ascii += `${rowNum} |`;
+
+      for (let col = 0; col < 8; col++) {
+        const piece = gameState.board[row][col];
+        ascii += ` ${piece} |`;
+      }
+
+      ascii += `\n  +---+---+---+---+---+---+---+---+\n`;
+    }
+
+    ascii += '    a   b   c   d   e   f   g   h\n';
+    ascii += '```\n';
+
+    const turn = gameState.whiteToMove ? 'White' : 'Black';
+    ascii += `\n${turn} to move`;
+
+    return ascii;
+  }
+
+  /**
+   * Converts algebraic notation to board coordinates
+   * @param {string} square - Square in algebraic notation (e.g., 'e2')
+   * @returns {Object|null} {row, col} or null if invalid
+   */
+  function parseSquare(square) {
+    if (!square || square.length !== 2) return null;
+
+    const col = square.charCodeAt(0) - 'a'.charCodeAt(0);
+    const row = 8 - parseInt(square[1], 10);
+
+    if (col < 0 || col > 7 || row < 0 || row > 7) return null;
+
+    return { row, col };
+  }
+
+  /**
+   * Checks if a piece belongs to the current player
+   * @param {string} piece - The piece character
+   * @param {boolean} whiteToMove - Whether it's white's turn
+   * @returns {boolean} True if piece belongs to current player
+   */
+  function isOwnPiece(piece, whiteToMove) {
+    if (piece === ' ') return false;
+    const isUpperCase = piece === piece.toUpperCase();
+    return whiteToMove === isUpperCase;
+  }
+
+  /**
+   * Attempts to move a piece (basic validation, no complex chess rules)
+   * @param {string} from - Starting square (e.g., 'e2')
+   * @param {string} to - Destination square (e.g., 'e4')
+   * @returns {boolean} True if move was successful
+   */
+  function makeMove(from, to) {
+    if (!gameState || !gameState.gameActive) return false;
+
+    const fromPos = parseSquare(from);
+    const toPos = parseSquare(to);
+
+    if (!fromPos || !toPos) {
+      appendSystemMessage(t?.chess?.invalidSquare || 'Invalid square notation');
+      return false;
+    }
+
+    const piece = gameState.board[fromPos.row][fromPos.col];
+
+    // Check if there's a piece at the source
+    if (piece === ' ') {
+      appendSystemMessage(t?.chess?.noPiece || 'No piece at source square');
+      return false;
+    }
+
+    // Check if it's the right player's turn
+    if (!isOwnPiece(piece, gameState.whiteToMove)) {
+      appendSystemMessage(t?.chess?.wrongPiece || 'Not your piece');
+      return false;
+    }
+
+    // Check if not moving to same square
+    if (fromPos.row === toPos.row && fromPos.col === toPos.col) {
+      appendSystemMessage(t?.chess?.sameSquare || 'Cannot move to same square');
+      return false;
+    }
+
+    // Basic move execution (no validation of legal chess moves as per requirements)
+    const capturedPiece = gameState.board[toPos.row][toPos.col];
+
+    // Don't capture own pieces
+    if (capturedPiece !== ' ' && isOwnPiece(capturedPiece, gameState.whiteToMove)) {
+      appendSystemMessage(t?.chess?.ownPiece || 'Cannot capture own piece');
+      return false;
+    }
+
+    // Execute the move
+    gameState.board[toPos.row][toPos.col] = piece;
+    gameState.board[fromPos.row][fromPos.col] = ' ';
+
+    // Switch turns
+    gameState.whiteToMove = !gameState.whiteToMove;
+
+    return true;
+  }
+
+  /**
+   * Sets up the Chess data channel for game synchronization
+   * @param {RTCDataChannel} channel - The Chess data channel
+   */
+  function setupChessChannel(channel) {
+    chessChannelRef.current = channel;
+
+    channel.onopen = () => {
+      appendSystemMessage(t?.chess?.channelReady || 'Chess channel ready');
+    };
+
+    channel.onclose = () => {
+      stopGame();
+      appendSystemMessage(t?.chess?.channelClosed || 'Chess channel closed');
+    };
+
+    channel.onerror = (err) => {
+      console.error('Chess channel error:', err);
+      appendSystemMessage(t?.chess?.channelError || 'Chess channel error');
+    };
+
+    channel.onmessage = (event) => {
+      // Security: Validate payload type
+      if (typeof event.data !== 'string') {
+        return;
+      }
+
+      try {
+        const data = JSON.parse(event.data);
+
+        // Security: Validate message structure
+        if (!data || typeof data !== 'object' || typeof data.type !== 'string') {
+          return;
+        }
+
+        handleChessMessage(data);
+      } catch (err) {
+        console.error('Failed to parse Chess message:', err);
+      }
+    };
+  }
+
+  /**
+   * Handles incoming Chess messages
+   * @param {Object} data - The message data
+   */
+  function handleChessMessage(data) {
+    switch (data.type) {
+      case 'start-game':
+        // Opponent initiated the game
+        startGame(false);
+        sendChessMessage({ type: 'game-started' });
+        const board = renderBoard();
+        appendMessage(board, 'system');
+        break;
+
+      case 'game-started':
+        // Opponent acknowledged game start
+        appendSystemMessage(t?.chess?.gameStarted || 'Chess game started!');
+        const startBoard = renderBoard();
+        appendMessage(startBoard, 'system');
+        break;
+
+      case 'move':
+        // Opponent made a move
+        if (gameState) {
+          // Security: Validate move data
+          if (typeof data.from !== 'string' || typeof data.to !== 'string') {
+            return;
+          }
+          // Security: Validate square notation format (a1-h8)
+          if (!/^[a-h][1-8]$/i.test(data.from) || !/^[a-h][1-8]$/i.test(data.to)) {
+            return;
+          }
+
+          const success = makeMove(data.from, data.to);
+          if (success) {
+            const boardAfterMove = renderBoard();
+            appendMessage(boardAfterMove, 'system');
+            appendSystemMessage(t?.chess?.opponentMoved || `Opponent moved: ${data.from}-${data.to}`);
+          }
+        }
+        break;
+
+      case 'end-game':
+        stopGame();
+        appendSystemMessage(t?.chess?.gameEnded || 'Chess game ended');
+        break;
+
+      default:
+        console.warn('Unknown Chess message type:', data.type);
+    }
+  }
+
+  /**
+   * Sends a Chess message over the data channel
+   * @param {Object} message - The message to send
+   */
+  function sendChessMessage(message) {
+    const channel = chessChannelRef.current;
+    if (channel && channel.readyState === 'open') {
+      try {
+        channel.send(JSON.stringify(message));
+      } catch (err) {
+        console.error('Failed to send Chess message:', err);
+      }
+    }
+  }
+
+  /**
+   * Starts a new chess game
+   * @param {boolean} asWhite - Whether this player plays white
+   */
+  function startGame(asWhite) {
+    // If there's an active game, end it first
+    if (gameState && gameState.gameActive) {
+      sendChessMessage({ type: 'end-game' });
+      stopGame();
+    }
+
+    initializeGameState(asWhite);
+
+    if (asWhite) {
+      sendChessMessage({ type: 'start-game' });
+      appendSystemMessage(t?.chess?.challengeSent || 'Chess challenge sent!');
+    }
+  }
+
+  /**
+   * Handles a move command from chat
+   * @param {string} from - Starting square
+   * @param {string} to - Destination square
+   * @returns {boolean} True if move was successful
+   */
+  function handleMove(from, to) {
+    if (!gameState || !gameState.gameActive) {
+      appendSystemMessage(t?.chess?.noActiveGame || 'No active chess game. Start one with @chess');
+      return false;
+    }
+
+    // Check if it's this player's turn
+    const isMyTurn = (isWhite && gameState.whiteToMove) || (!isWhite && !gameState.whiteToMove);
+
+    if (!isMyTurn) {
+      appendSystemMessage(t?.chess?.notYourTurn || 'Not your turn!');
+      return false;
+    }
+
+    const success = makeMove(from, to);
+
+    if (success) {
+      // Send move to opponent
+      sendChessMessage({
+        type: 'move',
+        from,
+        to
+      });
+
+      // Display updated board
+      const board = renderBoard();
+      appendMessage(board, 'system');
+
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Stops the chess game and cleans up
+   */
+  function stopGame() {
+    if (gameState) {
+      gameState.gameActive = false;
+    }
+    gameState = null;
+  }
+
+  /**
+   * Checks if a game is currently active
+   * @returns {boolean} True if game is active
+   */
+  function isGameActive() {
+    return gameState !== null && gameState.gameActive;
+  }
+
+  /**
+   * Gets the current game state
+   * @returns {Object|null} Current game state
+   */
+  function getGameState() {
+    return gameState;
+  }
+
+  return {
+    setupChessChannel,
+    startGame,
+    handleMove,
+    stopGame,
+    isGameActive,
+    getGameState
+  };
+}

--- a/src/managers/WebRTCManager.js
+++ b/src/managers/WebRTCManager.js
@@ -21,7 +21,8 @@ import {
   CONTROL_CHANNEL_LABEL,
   IMAGE_CHANNEL_LABEL,
   PONG_CHANNEL_LABEL,
-  TRIVIA_CHANNEL_LABEL
+  TRIVIA_CHANNEL_LABEL,
+  CHESS_CHANNEL_LABEL
 } from '../core/constants.js';
 
 /**
@@ -38,6 +39,7 @@ import {
  * @param {React.MutableRefObject} deps.imageChannelRef - Image channel reference
  * @param {React.MutableRefObject} deps.pongChannelRef - Pong channel reference
  * @param {React.MutableRefObject} deps.triviaChannelRef - Trivia channel reference
+ * @param {React.MutableRefObject} deps.chessChannelRef - Chess channel reference
  * @param {React.MutableRefObject} deps.incomingTimestampsRef - Rate limiting timestamps
  * @param {React.MutableRefObject} deps.canControlPeerRef - Remote control permission ref
  * @param {Function} deps.setStatus - Status setter
@@ -54,6 +56,7 @@ import {
  * @param {Function} deps.setupImageChannel - Image channel setup function
  * @param {Function} deps.setupPongChannel - Pong channel setup function
  * @param {Function} deps.setupTriviaChannel - Trivia channel setup function
+ * @param {Function} deps.setupChessChannel - Chess channel setup function
  * @param {Object} deps.t - Translation object
  * @returns {Object} WebRTC operations
  * @export
@@ -71,6 +74,7 @@ export function createWebRTCManager(deps) {
     imageChannelRef,
     pongChannelRef,
     triviaChannelRef,
+    chessChannelRef,
     incomingTimestampsRef,
     canControlPeerRef,
     setStatus,
@@ -87,6 +91,7 @@ export function createWebRTCManager(deps) {
     setupImageChannel,
     setupPongChannel,
     setupTriviaChannel,
+    setupChessChannel,
     t
   } = deps;
 
@@ -197,6 +202,10 @@ export function createWebRTCManager(deps) {
         setupTriviaChannel(incomingChannel);
         return;
       }
+      if (incomingChannel.label === CHESS_CHANNEL_LABEL) {
+        setupChessChannel(incomingChannel);
+        return;
+      }
 
       // Security: Close unexpected channels
       appendSystemMessage(t.systemMessages.channelBlocked(incomingChannel.label || ''));
@@ -298,6 +307,10 @@ export function createWebRTCManager(deps) {
     const triviaChannel = pc.createDataChannel(TRIVIA_CHANNEL_LABEL);
     triviaChannelRef.current = triviaChannel;
     setupTriviaChannel(triviaChannel);
+
+    const chessChannel = pc.createDataChannel(CHESS_CHANNEL_LABEL);
+    chessChannelRef.current = chessChannel;
+    setupChessChannel(chessChannel);
 
     // Reset state
     incomingTimestampsRef.current = [];
@@ -422,6 +435,10 @@ export function createWebRTCManager(deps) {
     if (triviaChannelRef.current) {
       triviaChannelRef.current.close();
       triviaChannelRef.current = null;
+    }
+    if (chessChannelRef.current) {
+      chessChannelRef.current.close();
+      chessChannelRef.current = null;
     }
 
     // Close peer connection


### PR DESCRIPTION
- if user enters @chess start a chess game between peers called players
- then for both players an ascii chess board will be rendered, figures denoted by english shortcuts, upper case letter of the english notation is used as follows: King Queen Rook kNight Bishop Pawn
- only one game can be active between two chat peers at a time, if a player enters @chess again, the current game will end and a new one started
- the initiator of the game begins.
- if it is his turn, he can enter @move followed by chess notation, eg e2-e4
- if its not the players turn he will get an error message
- otherwise the chessboard is updated and both player get the updated chessboard rendered
- for now there is no validation of moves or any end game check, we might do this in a different story
